### PR TITLE
Support HTTPS web sites

### DIFF
--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -15,6 +15,8 @@ if (version_compare(JVERSION, '3.0', '<')) {
 	$document->addScript(JURI::root() . "plugins/installer/webinstaller/js/jquery-migrate.min.js");
 }
 
+JLoader::import('joomla.environment.browser');
+
 /**
  * Support for the "Install from Web" tab
  *
@@ -30,6 +32,13 @@ class PlgInstallerWebinstaller extends JPlugin
 	private $_installfrom = null;
 	private $_j25 = null;
 	private $_rtl = null;
+	
+	public function __construct (&$subject, $config = array())
+	{
+		parent::__construct($subject, $config);
+
+		$this->appsBaseUrl = (JBrowser::getInstance()->isSSLConnection() ? "https" : "http") . '://appscdn.joomla.org/webapps/';
+	}
 
 	public function onInstallerBeforeDisplay(&$showJedAndWebInstaller)
 	{


### PR DESCRIPTION
When I have a Joomla web site which I access trough https, then the apps Base Urls needs to point to the https cdn.
This PR doesn't only change the cdn url to https but considers the actual browser connection. This works for http and none https connections from the client side.

More robust for #3 and #4.