### PR TITLE
 Move "Install from Web" to the last tab position #6375

### DIFF
--- a/plugins/installer/webinstaller/webinstaller.xml
+++ b/plugins/installer/webinstaller/webinstaller.xml
@@ -28,7 +28,7 @@
 			<fieldset name="basic">
 				<field name="tab_position" type="radio"
 					class="btn-group"
-					default="0"
+					default="1"
 					description="PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_DESC"
 					label="PLG_INSTALLER_WEBINSTALLER_TAB_POSITION_LABEL"
 				>


### PR DESCRIPTION
Right now "Install from Web" shows this message "We are sorry but due..."

There is no defined date when the new "Install from Web" is going to be available.

Meanwhile, to avoid this message, plugin can be moved to the last tab position, just a simple change in webinstaller.xml:

```
            default="1"
```
