### PR TITLE
Ensure the tab loads in fringe cases in recent Joomla versions

### DIFF
--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -137,6 +137,12 @@ jQuery(document).ready(function() {
 			}
 		}
 	}
+	
+	jQuery('#myTabTabs a[href="#web"]').on('shown.bs.tab', function (e) {
+        	if (!Joomla.apps.loaded){
+           		Joomla.apps.initialize();
+        	}
+    	});
 });
 
 		


### PR DESCRIPTION
Adds an additional check on page load, and if the tab content has not been initialized, but the tab is shown, then load the content. 

This Closes #50